### PR TITLE
Add Neo4j-powered Business Leader Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,125 @@
-# Ruby on Rails Tutorial: first application
+# Business Leader Network
 
-This is the first application for the
-[*Ruby on Rails Tutorial*](http://railstutorial.org/)
-by [Michael Hartl](http://michaelhartl.com/).
+A graph-powered B2B sales and marketing intelligence application built with Ruby on Rails and Neo4j — inspired by [Kantwert's presentation at GraphConnect](https://neo4j.com/blog/cypher-and-gql/the-power-of-business-leader-networks/).
+
+## What it does
+
+Maps professional relationships between business leaders so sales and marketing teams can:
+
+- **Find introduction paths** — shortest connection chain to any target leader ("6 degrees" warm intro)
+- **Identify top connectors** — bridge nodes that unlock the largest portions of the network
+- **Target by industry** — all reachable leaders in FinTech, HealthTech, CleanTech, etc.
+- **Explore company networks** — employees, board members, and alumni for any company
+- **Analyse mutual connections** — shared contacts between any two leaders
+
+## Graph Schema
+
+```
+(:BusinessLeader {id, name, title, email, linkedin_url, bio, influence_score})
+  -[:WORKS_AT      {since, current}]->          (:Company)
+  -[:KNOWS         {since, source, strength}]->  (:BusinessLeader)
+  -[:BOARD_MEMBER_OF {since}]->                  (:Company)
+  -[:PREVIOUSLY_WORKED_AT {from, to, title}]->   (:Company)
+
+(:Company {id, name, industry, size, hq_city, website, description})
+(:Industry {name})
+```
+
+## Key Cypher Queries
+
+**Shortest introduction path**
+```cypher
+MATCH path = shortestPath(
+  (source:BusinessLeader {id: $source_id})-[:KNOWS*..6]-(target:BusinessLeader {id: $target_id})
+)
+RETURN nodes(path)
+```
+
+**Extended network within N hops**
+```cypher
+MATCH (source:BusinessLeader {id: $id})-[:KNOWS*1..$hops]-(reachable:BusinessLeader)
+WHERE source <> reachable
+RETURN DISTINCT reachable ORDER BY reachable.influence_score DESC
+```
+
+**Top connectors (bridge nodes)**
+```cypher
+MATCH (l:BusinessLeader)-[:KNOWS]-(other)
+WITH l, count(DISTINCT other) AS degree
+RETURN l.name, degree ORDER BY degree DESC
+```
+
+**B2B industry targeting**
+```cypher
+MATCH (l:BusinessLeader)-[:WORKS_AT {current: true}]->(c:Company {industry: $industry})
+OPTIONAL MATCH (l)-[:KNOWS]-(other)
+WITH l, c, count(DISTINCT other) AS connections
+RETURN l.name, c.name, connections ORDER BY connections DESC
+```
+
+**Mutual connections**
+```cypher
+MATCH (a:BusinessLeader {id: $id})-[:KNOWS]-(mutual)-[:KNOWS]-(b:BusinessLeader {id: $other_id})
+WHERE a <> b AND mutual <> a AND mutual <> b
+RETURN DISTINCT mutual
+```
+
+## Setup
+
+### 1. Install & start Neo4j
+
+Download Neo4j Community Edition from https://neo4j.com/download/
+Default credentials: `neo4j` / `password` (change via Neo4j Browser on first login)
+
+### 2. Configure environment
+
+```bash
+export NEO4J_URL=http://localhost:7474
+export NEO4J_USERNAME=neo4j
+export NEO4J_PASSWORD=your_password
+```
+
+### 3. Install Ruby dependencies
+
+```bash
+bundle install
+```
+
+### 4. Seed the graph
+
+```bash
+rake db:seed
+```
+
+This loads 20 business leaders across 8 companies (FinTech, Data & AI, Cybersecurity, HealthTech, Real Estate, SaaS/ERP, CleanTech, Media), 38 KNOWS relationships, 7 board seats, and 7 work-history entries.
+
+### 5. Start the server
+
+```bash
+rails server
+```
+
+Open http://localhost:3000
+
+## Rake Tasks
+
+```bash
+rake neo4j:status          # Check connection and print graph stats
+rake neo4j:top_connectors  # Print top-connected leaders to stdout
+rake neo4j:reset           # Clear all graph data (prompts for confirmation)
+rake CYPHER='...' neo4j:query  # Run a raw Cypher query
+```
+
+## Architecture
+
+| File | Purpose |
+|------|---------|
+| `lib/neo4j/client.rb` | Raw HTTP client for Neo4j's transactional Cypher endpoint |
+| `config/initializers/neo4j.rb` | Boot-time connection + schema/index creation |
+| `app/models/business_leader.rb` | Graph ORM for `:BusinessLeader` nodes + path queries |
+| `app/models/company.rb` | Graph ORM for `:Company` nodes |
+| `app/controllers/business_leaders_controller.rb` | Profile, network, path, mutual views |
+| `app/controllers/companies_controller.rb` | Company directory and detail |
+| `app/controllers/network_controller.rb` | Dashboard, top connectors, industry targeting |
+| `db/seeds.rb` | Sample graph with 20 leaders, 8 companies, 38 connections |
+| `lib/tasks/neo4j.rake` | Operational rake tasks |

--- a/app/controllers/business_leaders_controller.rb
+++ b/app/controllers/business_leaders_controller.rb
@@ -1,0 +1,56 @@
+class BusinessLeadersController < ApplicationController
+  # GET /business_leaders
+  def index
+    @leaders = if params[:q].present?
+                 BusinessLeader.search(params[:q])
+               else
+                 BusinessLeader.all
+               end
+  end
+
+  # GET /business_leaders/:id
+  def show
+    @leader = BusinessLeader.find(params[:id])
+    return render :not_found unless @leader
+
+    @connections     = @leader.connections
+    @current_company = @leader.current_company
+    @board_seats     = @leader.board_seats
+    @work_history    = @leader.work_history
+  end
+
+  # GET /business_leaders/:id/network
+  # Returns the extended network up to N hops for B2B targeting
+  def network
+    @leader = BusinessLeader.find(params[:id])
+    return render :not_found unless @leader
+
+    hops = (params[:hops] || 2).to_i.clamp(1, 3)
+    @network_leaders = @leader.network_within(hops)
+    @hops = hops
+  end
+
+  # GET /business_leaders/:id/path?target_id=…
+  # Introduction chain: who can introduce me to the target leader?
+  def path
+    @leader = BusinessLeader.find(params[:id])
+    return render :not_found unless @leader
+
+    @target = BusinessLeader.find(params[:target_id])
+    return render :not_found unless @target
+
+    @path    = @leader.introduction_path_to(@target.id)
+    @degrees = @path.length - 1
+  end
+
+  # GET /business_leaders/:id/mutual?other_id=…
+  def mutual
+    @leader = BusinessLeader.find(params[:id])
+    return render :not_found unless @leader
+
+    @other   = BusinessLeader.find(params[:other_id])
+    return render :not_found unless @other
+
+    @mutual = @leader.mutual_connections_with(@other.id)
+  end
+end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,0 +1,21 @@
+class CompaniesController < ApplicationController
+  # GET /companies
+  def index
+    @companies  = if params[:industry].present?
+                    Company.by_industry(params[:industry])
+                  else
+                    Company.all
+                  end
+    @industries = Company.industries
+  end
+
+  # GET /companies/:id
+  def show
+    @company      = Company.find(params[:id])
+    return render :not_found unless @company
+
+    @employees    = @company.current_employees
+    @board        = @company.board_members
+    @alumni       = @company.alumni
+  end
+end

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -1,0 +1,67 @@
+# High-level B2B intelligence queries that span the whole graph
+class NetworkController < ApplicationController
+  # GET /network
+  # Dashboard with top influencers and recent stats
+  def index
+    @top_leaders = NEO4J.query(<<~CYPHER)
+      MATCH (l:BusinessLeader)
+      OPTIONAL MATCH (l)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             c.name AS company_name, l.influence_score AS influence_score
+      ORDER BY l.influence_score DESC
+      LIMIT 10
+    CYPHER
+
+    @stats = {
+      leaders:       NEO4J.query('MATCH (l:BusinessLeader) RETURN count(l) AS n').first&.fetch('n', 0),
+      companies:     NEO4J.query('MATCH (c:Company) RETURN count(c) AS n').first&.fetch('n', 0),
+      connections:   NEO4J.query('MATCH ()-[r:KNOWS]->() RETURN count(r) AS n').first&.fetch('n', 0),
+      board_seats:   NEO4J.query('MATCH ()-[r:BOARD_MEMBER_OF]->() RETURN count(r) AS n').first&.fetch('n', 0),
+    }
+
+    @industries = NEO4J.query(<<~CYPHER)
+      MATCH (c:Company)<-[:WORKS_AT {current: true}]-(l:BusinessLeader)
+      RETURN c.industry AS industry, count(DISTINCT l) AS leader_count
+      ORDER BY leader_count DESC
+    CYPHER
+  end
+
+  # GET /network/top_connectors
+  # Business leaders with the most connections — the key "bridge nodes" for
+  # reaching new prospects (the warm-intro strategy described in the article)
+  def top_connectors
+    @connectors = NEO4J.query(<<~CYPHER)
+      MATCH (l:BusinessLeader)-[:KNOWS]-(other)
+      WITH l, count(DISTINCT other) AS degree
+      OPTIONAL MATCH (l)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             c.name AS company_name, l.influence_score AS influence_score,
+             degree
+      ORDER BY degree DESC
+      LIMIT 20
+    CYPHER
+  end
+
+  # GET /network/by_industry?industry=FinTech
+  # All leaders in a given industry with their connection counts —
+  # the primary B2B targeting view
+  def by_industry
+    @industry = params[:industry]
+    return redirect_to network_path unless @industry.present?
+
+    @leaders = NEO4J.query(<<~CYPHER, industry: @industry)
+      MATCH (l:BusinessLeader)-[:WORKS_AT {current: true}]->(c:Company {industry: $industry})
+      OPTIONAL MATCH (l)-[:KNOWS]-(other)
+      WITH l, c, count(DISTINCT other) AS connections
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             c.name AS company_name, l.influence_score AS influence_score,
+             connections
+      ORDER BY connections DESC, l.influence_score DESC
+    CYPHER
+
+    @industries = NEO4J.query(<<~CYPHER)
+      MATCH (c:Company)
+      RETURN DISTINCT c.industry AS industry ORDER BY industry
+    CYPHER
+  end
+end

--- a/app/models/business_leader.rb
+++ b/app/models/business_leader.rb
@@ -1,0 +1,212 @@
+# Represents a (:BusinessLeader) node in the graph.
+#
+# Graph schema
+# ============
+#   (:BusinessLeader {id, name, title, email, linkedin_url, bio, influence_score})
+#     -[:WORKS_AT   {since, title, current}]->  (:Company)
+#     -[:KNOWS      {since, source, strength}]-> (:BusinessLeader)
+#     -[:BOARD_MEMBER_OF {since}]->              (:Company)
+#     -[:PREVIOUSLY_WORKED_AT {from, to, title}]->(:Company)
+#
+class BusinessLeader
+  attr_accessor :id, :name, :title, :email, :linkedin_url, :bio, :influence_score
+
+  def initialize(attrs = {})
+    attrs.each { |k, v| public_send(:"#{k}=", v) if respond_to?(:"#{k}=") }
+  end
+
+  # ── Finders ──────────────────────────────────────────────────────────────
+
+  def self.all
+    rows = db.query(<<~CYPHER)
+      MATCH (l:BusinessLeader)
+      OPTIONAL MATCH (l)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             l.email AS email, l.linkedin_url AS linkedin_url,
+             l.bio AS bio, l.influence_score AS influence_score,
+             c.name AS company_name
+      ORDER BY l.name
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  def self.find(id)
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader {id: $id})
+      OPTIONAL MATCH (l)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             l.email AS email, l.linkedin_url AS linkedin_url,
+             l.bio AS bio, l.influence_score AS influence_score,
+             c.name AS company_name
+    CYPHER
+    rows.first ? from_row(rows.first) : nil
+  end
+
+  def self.search(query)
+    q = "(?i).*#{Regexp.escape(query)}.*"
+    rows = db.query(<<~CYPHER, q: ".*#{query.downcase}.*")
+      MATCH (l:BusinessLeader)
+      WHERE toLower(l.name) CONTAINS toLower($q)
+         OR toLower(l.title) CONTAINS toLower($q)
+      OPTIONAL MATCH (l)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             l.email AS email, l.linkedin_url AS linkedin_url,
+             l.bio AS bio, l.influence_score AS influence_score,
+             c.name AS company_name
+      ORDER BY l.influence_score DESC
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  # ── Relationships ─────────────────────────────────────────────────────────
+
+  # Direct connections (1st-degree KNOWS relationships)
+  def connections
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader {id: $id})-[r:KNOWS]-(other:BusinessLeader)
+      OPTIONAL MATCH (other)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN other.id AS id, other.name AS name, other.title AS title,
+             other.email AS email, other.linkedin_url AS linkedin_url,
+             other.bio AS bio, other.influence_score AS influence_score,
+             c.name AS company_name,
+             r.since AS connected_since, r.source AS source, r.strength AS strength
+      ORDER BY r.strength DESC, other.name
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  # Current company
+  def current_company
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader {id: $id})-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN c.id AS id, c.name AS name, c.industry AS industry,
+             c.size AS size, c.website AS website, c.hq_city AS hq_city
+    CYPHER
+    rows.first ? Company.from_row(rows.first) : nil
+  end
+
+  # Companies on whose board this leader sits
+  def board_seats
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader {id: $id})-[r:BOARD_MEMBER_OF]->(c:Company)
+      RETURN c.id AS id, c.name AS name, c.industry AS industry,
+             c.size AS size, c.website AS website, c.hq_city AS hq_city,
+             r.since AS since
+    CYPHER
+    rows.map { |r| Company.from_row(r) }
+  end
+
+  # Work history
+  def work_history
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader {id: $id})-[r:PREVIOUSLY_WORKED_AT]->(c:Company)
+      RETURN c.id AS id, c.name AS name, c.industry AS industry,
+             c.size AS size, c.website AS website, c.hq_city AS hq_city,
+             r.from AS from, r.to AS to, r.title AS title
+      ORDER BY r.to DESC
+    CYPHER
+    rows
+  end
+
+  # Mutual connections between this leader and another
+  def mutual_connections_with(other_id)
+    rows = db.query(<<~CYPHER, id: id, other_id: other_id)
+      MATCH (a:BusinessLeader {id: $id})-[:KNOWS]-(mutual:BusinessLeader)-[:KNOWS]-(b:BusinessLeader {id: $other_id})
+      WHERE a <> b AND mutual <> a AND mutual <> b
+      OPTIONAL MATCH (mutual)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN DISTINCT mutual.id AS id, mutual.name AS name,
+             mutual.title AS title, c.name AS company_name
+      ORDER BY mutual.name
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  # ── Network / Path Analysis ───────────────────────────────────────────────
+
+  # Find the shortest introduction path between this leader and a target.
+  # Returns the ordered list of nodes in the chain.
+  def introduction_path_to(target_id)
+    rows = db.query(<<~CYPHER, source_id: id, target_id: target_id)
+      MATCH path = shortestPath(
+        (source:BusinessLeader {id: $source_id})-[:KNOWS*..6]-(target:BusinessLeader {id: $target_id})
+      )
+      UNWIND nodes(path) AS node
+      OPTIONAL MATCH (node)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN node.id AS id, node.name AS name, node.title AS title,
+             c.name AS company_name
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  # Degree of separation (hop count) to another leader
+  def degrees_to(target_id)
+    rows = db.query(<<~CYPHER, source_id: id, target_id: target_id)
+      MATCH path = shortestPath(
+        (source:BusinessLeader {id: $source_id})-[:KNOWS*..10]-(target:BusinessLeader {id: $target_id})
+      )
+      RETURN length(path) AS hops
+    CYPHER
+    rows.first ? rows.first['hops'] : nil
+  end
+
+  # Leaders reachable within N hops (default 2) — useful for B2B targeting
+  def network_within(hops = 2)
+    rows = db.query(<<~CYPHER, id: id, hops: hops)
+      MATCH (source:BusinessLeader {id: $id})-[:KNOWS*1..$hops]-(reachable:BusinessLeader)
+      WHERE source <> reachable
+      OPTIONAL MATCH (reachable)-[:WORKS_AT {current: true}]->(c:Company)
+      RETURN DISTINCT reachable.id AS id, reachable.name AS name,
+             reachable.title AS title, c.name AS company_name,
+             reachable.influence_score AS influence_score
+      ORDER BY reachable.influence_score DESC
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  # ── Persistence ───────────────────────────────────────────────────────────
+
+  def self.create(attrs)
+    attrs[:id] ||= SecureRandom.uuid
+    attrs[:influence_score] ||= 0
+    db.query(<<~CYPHER, attrs.transform_keys(&:to_s))
+      CREATE (l:BusinessLeader {
+        id:              $id,
+        name:            $name,
+        title:           $title,
+        email:           $email,
+        linkedin_url:    $linkedin_url,
+        bio:             $bio,
+        influence_score: toInteger($influence_score)
+      })
+      RETURN l.id AS id
+    CYPHER
+    find(attrs[:id])
+  end
+
+  def self.connect(leader_id_a, leader_id_b, since: nil, source: 'manual', strength: 5)
+    db.query(<<~CYPHER, a: leader_id_a, b: leader_id_b, since: since, source: source, strength: strength)
+      MATCH (a:BusinessLeader {id: $a}), (b:BusinessLeader {id: $b})
+      MERGE (a)-[:KNOWS {since: $since, source: $source, strength: $strength}]->(b)
+    CYPHER
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────────
+
+  def self.from_row(row)
+    leader = new(row)
+    leader.id ||= row['id']
+    leader
+  end
+
+  def self.db
+    NEO4J
+  end
+
+  def db
+    self.class.db
+  end
+
+  def to_param
+    id
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,0 +1,129 @@
+# Represents a (:Company) node in the graph.
+#
+# A company is the anchor for employment and board membership relationships.
+# Industry segmentation enables B2B targeting ("show me all leaders in FinTech").
+class Company
+  attr_accessor :id, :name, :industry, :size, :website, :hq_city, :description
+  # Extra attrs surfaced by some queries
+  attr_accessor :since, :from, :to, :role_title
+
+  def initialize(attrs = {})
+    attrs.each { |k, v| public_send(:"#{k}=", v) if respond_to?(:"#{k}=") }
+  end
+
+  # ── Finders ──────────────────────────────────────────────────────────────
+
+  def self.all
+    rows = db.query(<<~CYPHER)
+      MATCH (c:Company)
+      RETURN c.id AS id, c.name AS name, c.industry AS industry,
+             c.size AS size, c.website AS website, c.hq_city AS hq_city,
+             c.description AS description
+      ORDER BY c.name
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  def self.find(id)
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (c:Company {id: $id})
+      RETURN c.id AS id, c.name AS name, c.industry AS industry,
+             c.size AS size, c.website AS website, c.hq_city AS hq_city,
+             c.description AS description
+    CYPHER
+    rows.first ? from_row(rows.first) : nil
+  end
+
+  def self.by_industry(industry)
+    rows = db.query(<<~CYPHER, industry: industry)
+      MATCH (c:Company {industry: $industry})
+      RETURN c.id AS id, c.name AS name, c.industry AS industry,
+             c.size AS size, c.website AS website, c.hq_city AS hq_city,
+             c.description AS description
+      ORDER BY c.name
+    CYPHER
+    rows.map { |r| from_row(r) }
+  end
+
+  def self.industries
+    rows = db.query(<<~CYPHER)
+      MATCH (c:Company)
+      RETURN DISTINCT c.industry AS industry
+      ORDER BY industry
+    CYPHER
+    rows.map { |r| r['industry'] }.compact
+  end
+
+  # ── Relationships ─────────────────────────────────────────────────────────
+
+  # Current employees
+  def current_employees
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader)-[:WORKS_AT {current: true}]->(c:Company {id: $id})
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             l.email AS email, l.linkedin_url AS linkedin_url,
+             l.bio AS bio, l.influence_score AS influence_score
+      ORDER BY l.influence_score DESC
+    CYPHER
+    rows.map { |r| BusinessLeader.from_row(r) }
+  end
+
+  # Board members
+  def board_members
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader)-[r:BOARD_MEMBER_OF]->(c:Company {id: $id})
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             l.email AS email, l.linkedin_url AS linkedin_url,
+             l.bio AS bio, l.influence_score AS influence_score,
+             r.since AS since
+      ORDER BY l.name
+    CYPHER
+    rows.map { |r| BusinessLeader.from_row(r) }
+  end
+
+  # Alumni (previously worked here)
+  def alumni
+    rows = db.query(<<~CYPHER, id: id)
+      MATCH (l:BusinessLeader)-[r:PREVIOUSLY_WORKED_AT]->(c:Company {id: $id})
+      RETURN l.id AS id, l.name AS name, l.title AS title,
+             l.email AS email, l.linkedin_url AS linkedin_url,
+             l.bio AS bio, l.influence_score AS influence_score,
+             r.from AS from, r.to AS to, r.title AS role_title
+      ORDER BY r.to DESC, l.name
+    CYPHER
+    rows.map { |r| BusinessLeader.from_row(r) }
+  end
+
+  # ── Persistence ───────────────────────────────────────────────────────────
+
+  def self.create(attrs)
+    attrs[:id] ||= SecureRandom.uuid
+    db.query(<<~CYPHER, attrs.transform_keys(&:to_s))
+      CREATE (c:Company {
+        id:          $id,
+        name:        $name,
+        industry:    $industry,
+        size:        $size,
+        website:     $website,
+        hq_city:     $hq_city,
+        description: $description
+      })
+      RETURN c.id AS id
+    CYPHER
+    find(attrs[:id])
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────────
+
+  def self.from_row(row)
+    new(row)
+  end
+
+  def self.db
+    NEO4J
+  end
+
+  def to_param
+    id
+  end
+end

--- a/app/views/business_leaders/index.html.erb
+++ b/app/views/business_leaders/index.html.erb
@@ -1,0 +1,27 @@
+<h1>Business Leaders</h1>
+
+<%= form_tag business_leaders_path, method: :get, class: "search-bar" do %>
+  <%= text_field_tag :q, params[:q], placeholder: "Search by name or title…" %>
+  <%= submit_tag "Search" %>
+<% end %>
+
+<div class="leader-grid">
+  <% @leaders.each do |leader| %>
+    <div class="leader-card">
+      <h3><%= link_to leader.name, business_leader_path(leader) %></h3>
+      <div class="title"><%= leader.title %></div>
+      <% if leader.respond_to?(:company_name) && leader.company_name.present? %>
+        <div class="company"><%= leader.company_name %></div>
+      <% end %>
+      <div style="margin-top: 10px; display: flex; gap: 8px;">
+        <%= link_to "Profile",  business_leader_path(leader), style: "font-size:0.82rem;" %>
+        &middot;
+        <%= link_to "Network",  network_business_leader_path(leader), style: "font-size:0.82rem;" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<% if @leaders.empty? %>
+  <p class="empty">No leaders found.</p>
+<% end %>

--- a/app/views/business_leaders/mutual.html.erb
+++ b/app/views/business_leaders/mutual.html.erb
@@ -1,0 +1,27 @@
+<h1>Mutual Connections</h1>
+<p style="color:#7f8c8d; margin-bottom: 24px;">
+  People who know both <strong><%= @leader.name %></strong> and <strong><%= @other.name %></strong>.
+</p>
+
+<% if @mutual.any? %>
+  <div class="leader-grid">
+    <% @mutual.each do |m| %>
+      <div class="leader-card">
+        <h3><%= link_to m.name, business_leader_path(m) %></h3>
+        <div class="title"><%= m.title %></div>
+        <% if m.respond_to?(:company_name) && m.company_name.present? %>
+          <div class="company"><%= m.company_name %></div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="card">
+    <p class="empty">No mutual connections found.</p>
+  </div>
+<% end %>
+
+<div style="margin-top: 16px; display: flex; gap: 16px;">
+  <%= link_to "← #{@leader.name}", business_leader_path(@leader) %>
+  <%= link_to "#{@other.name} →", business_leader_path(@other) %>
+</div>

--- a/app/views/business_leaders/network.html.erb
+++ b/app/views/business_leaders/network.html.erb
@@ -1,0 +1,49 @@
+<h1><%= @leader.name %> — Extended Network</h1>
+<p style="color:#7f8c8d; margin-bottom:20px;">
+  <%= @leader.name %>'s reachable network within <%= @hops %> degrees of separation.
+  These are the contacts you can reach via warm introduction — a core B2B strategy.
+</p>
+
+<div style="margin-bottom: 20px; display: flex; gap: 8px; align-items: center;">
+  <strong style="font-size:0.85rem; color:#7f8c8d;">Hops:</strong>
+  <%= link_to "1°", network_business_leader_path(@leader, hops: 1),
+      style: @hops == 1 ? "background:#1a6fa0;color:white;padding:4px 12px;border-radius:12px;" : "padding:4px 12px;" %>
+  <%= link_to "2°", network_business_leader_path(@leader, hops: 2),
+      style: @hops == 2 ? "background:#1a6fa0;color:white;padding:4px 12px;border-radius:12px;" : "padding:4px 12px;" %>
+  <%= link_to "3°", network_business_leader_path(@leader, hops: 3),
+      style: @hops == 3 ? "background:#1a6fa0;color:white;padding:4px 12px;border-radius:12px;" : "padding:4px 12px;" %>
+</div>
+
+<div class="stat-row" style="margin-bottom: 24px;">
+  <div class="stat-box">
+    <div class="number"><%= @network_leaders.length %></div>
+    <div class="label">Reachable leaders</div>
+  </div>
+  <div class="stat-box">
+    <div class="number"><%= @network_leaders.map { |l| l.respond_to?(:company_name) ? l.company_name : nil }.compact.uniq.length %></div>
+    <div class="label">Companies reachable</div>
+  </div>
+</div>
+
+<div class="leader-grid">
+  <% @network_leaders.each do |leader| %>
+    <div class="leader-card">
+      <h3><%= link_to leader.name, business_leader_path(leader) %></h3>
+      <div class="title"><%= leader.title %></div>
+      <% if leader.respond_to?(:company_name) && leader.company_name.present? %>
+        <div class="company"><%= leader.company_name %></div>
+      <% end %>
+      <div style="margin-top: 8px; font-size: 0.82rem;">
+        <%= link_to "Find path →", path_business_leader_path(@leader, target_id: leader.id) %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<% if @network_leaders.empty? %>
+  <p class="empty">No connections found within <%= @hops %> degrees.</p>
+<% end %>
+
+<div style="margin-top: 24px;">
+  <%= link_to "← Back to profile", business_leader_path(@leader) %>
+</div>

--- a/app/views/business_leaders/path.html.erb
+++ b/app/views/business_leaders/path.html.erb
@@ -1,0 +1,49 @@
+<h1>Introduction Path</h1>
+<p style="color:#7f8c8d; margin-bottom:24px;">
+  The shortest connection chain between
+  <strong><%= @leader.name %></strong> and <strong><%= @target.name %></strong>.
+</p>
+
+<% if @path.any? %>
+  <div class="card">
+    <div style="font-size: 0.85rem; color:#7f8c8d; margin-bottom: 12px;">
+      <span class="badge badge-degree"><%= @degrees %> degree<%= @degrees == 1 ? '' : 's' %> of separation</span>
+    </div>
+
+    <div class="path-chain">
+      <% @path.each_with_index do |node, i| %>
+        <div class="path-node">
+          <strong><%= link_to node.name, business_leader_path(node) %></strong><br>
+          <span style="font-size:0.78rem; color:#7f8c8d;">
+            <%= node.title %>
+            <% if node.respond_to?(:company_name) && node.company_name.present? %>
+              &middot; <%= node.company_name %>
+            <% end %>
+          </span>
+        </div>
+        <% unless i == @path.length - 1 %>
+          <span class="path-arrow">→</span>
+        <% end %>
+      <% end %>
+    </div>
+
+    <p style="font-size:0.85rem; color:#7f8c8d; margin-top: 16px;">
+      To reach <strong><%= @target.name %></strong>, ask
+      <% if @path.length > 2 %>
+        <strong><%= @path[1].name %></strong>
+        <% if @path.length > 3 %> to forward the introduction via the chain above<% else %> to make the introduction<% end %>.
+      <% else %>
+        you are already directly connected.
+      <% end %>
+    </p>
+  </div>
+<% else %>
+  <div class="card">
+    <p class="empty">No path found between these two leaders within 6 degrees of separation.</p>
+  </div>
+<% end %>
+
+<div style="margin-top: 16px; display: flex; gap: 16px;">
+  <%= link_to "← Back to #{@leader.name}", business_leader_path(@leader) %>
+  <%= link_to "#{@target.name}'s profile →", business_leader_path(@target) %>
+</div>

--- a/app/views/business_leaders/show.html.erb
+++ b/app/views/business_leaders/show.html.erb
@@ -1,0 +1,89 @@
+<div style="display: flex; align-items: flex-start; gap: 32px; flex-wrap: wrap;">
+  <div style="flex: 2; min-width: 280px;">
+    <h1 style="margin-bottom: 4px;"><%= @leader.name %></h1>
+    <div style="font-size: 1.05rem; color: #7f8c8d; margin-bottom: 8px;"><%= @leader.title %></div>
+    <% if @current_company %>
+      <div style="margin-bottom: 12px;">
+        <%= link_to @current_company.name, company_path(@current_company) %> &middot;
+        <span class="badge badge-industry"><%= @current_company.industry %></span>
+        <span style="color:#aaa; font-size:0.82rem;"> <%= @current_company.hq_city %></span>
+      </div>
+    <% end %>
+    <% if @leader.bio.present? %>
+      <p style="color:#4a5568; font-size:0.95rem;"><%= @leader.bio %></p>
+    <% end %>
+    <div style="margin-top: 16px; display: flex; gap: 12px;">
+      <%= link_to "View Network (2° hops)", network_business_leader_path(@leader),
+          style: "background:#5dade2;color:white;padding:8px 16px;border-radius:6px;font-size:0.9rem;" %>
+    </div>
+  </div>
+
+  <div style="flex: 1; min-width: 200px;">
+    <div class="card" style="text-align: center; padding: 16px;">
+      <div style="font-size: 2rem; font-weight: 700; color: #5dade2;"><%= @leader.influence_score %></div>
+      <div style="font-size: 0.78rem; color: #7f8c8d; text-transform: uppercase;">Influence Score</div>
+    </div>
+    <div class="card" style="padding: 16px;">
+      <div style="font-size: 0.78rem; color: #7f8c8d; text-transform: uppercase; margin-bottom: 6px;">Find Introduction</div>
+      <%= form_tag path_business_leader_path(@leader), method: :get, style: "display:flex;gap:6px;" do %>
+        <%= text_field_tag :target_id, nil, placeholder: "Target leader ID…",
+            style: "flex:1; padding:6px 10px; border:1px solid #d5dce6; border-radius:4px; font-size:0.85rem;" %>
+        <%= submit_tag "→", style: "padding:6px 12px; background:#1a2a4a; color:white; border:none; border-radius:4px; cursor:pointer;" %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="section-title">Direct Connections (<%= @connections.length %>)</div>
+<% if @connections.any? %>
+  <div class="leader-grid">
+    <% @connections.each do |conn| %>
+      <div class="leader-card" style="border-left-color: <%= conn.respond_to?(:strength) && conn.strength.to_i >= 8 ? '#2ecc71' : '#5dade2' %>;">
+        <h3><%= link_to conn.name, business_leader_path(conn) %></h3>
+        <div class="title"><%= conn.title %></div>
+        <% if conn.respond_to?(:company_name) && conn.company_name.present? %>
+          <div class="company"><%= conn.company_name %></div>
+        <% end %>
+        <div style="display: flex; gap: 8px; margin-top: 10px; font-size: 0.82rem;">
+          <%= link_to "Mutual connections", mutual_business_leader_path(@leader, other_id: conn.id) %>
+          &middot;
+          <%= link_to "Path", path_business_leader_path(@leader, target_id: conn.id) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="empty">No direct connections recorded.</p>
+<% end %>
+
+<% if @board_seats.any? %>
+  <div class="section-title">Board Memberships</div>
+  <div class="leader-grid">
+    <% @board_seats.each do |co| %>
+      <div class="leader-card" style="border-left-color: #8e44ad;">
+        <h3><%= link_to co.name, company_path(co) %></h3>
+        <div class="title"><%= co.industry %></div>
+        <div class="company"><%= co.hq_city %></div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @work_history.any? %>
+  <div class="section-title">Work History</div>
+  <div class="card">
+    <table>
+      <thead><tr><th>Company</th><th>Title</th><th>From</th><th>To</th></tr></thead>
+      <tbody>
+        <% @work_history.each do |w| %>
+          <tr>
+            <td><%= w['name'] %></td>
+            <td><%= w['title'] %></td>
+            <td><%= w['from'] %></td>
+            <td><%= w['to'] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -1,0 +1,28 @@
+<h1>Companies</h1>
+
+<div style="margin-bottom: 20px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+  <%= link_to "All", companies_path,
+      style: params[:industry].blank? ? "background:#1a6fa0;color:white;padding:4px 14px;border-radius:12px;" : "padding:4px 14px;color:#1a6fa0;" %>
+  <% @industries.each do |ind| %>
+    <%= link_to ind, companies_path(industry: ind),
+        class: "badge badge-industry",
+        style: params[:industry] == ind ? "background:#1a6fa0;color:white;" : "" %>
+  <% end %>
+</div>
+
+<div class="leader-grid">
+  <% @companies.each do |co| %>
+    <div class="leader-card" style="border-left-color: #8e44ad;">
+      <h3><%= link_to co.name, company_path(co) %></h3>
+      <div class="title"><%= co.hq_city %></div>
+      <div style="margin-top: 6px;">
+        <span class="badge badge-industry"><%= co.industry %></span>
+        <span style="font-size:0.8rem; color:#7f8c8d; margin-left: 8px;"><%= co.size %></span>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<% if @companies.empty? %>
+  <p class="empty">No companies found.</p>
+<% end %>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -1,0 +1,62 @@
+<h1><%= @company.name %></h1>
+<div style="display: flex; gap: 12px; align-items: center; margin-bottom: 20px; flex-wrap: wrap;">
+  <span class="badge badge-industry"><%= @company.industry %></span>
+  <span style="color:#7f8c8d;"><%= @company.hq_city %></span>
+  <% if @company.size.present? %>
+    <span style="color:#7f8c8d; font-size:0.85rem;"><%= @company.size %> employees</span>
+  <% end %>
+  <% if @company.website.present? %>
+    <a href="<%= @company.website %>" target="_blank" style="font-size:0.85rem;"><%= @company.website %></a>
+  <% end %>
+</div>
+
+<% if @company.description.present? %>
+  <p style="color:#4a5568; margin-bottom:24px;"><%= @company.description %></p>
+<% end %>
+
+<div class="section-title">Current Employees (<%= @employees.length %>)</div>
+<% if @employees.any? %>
+  <div class="leader-grid">
+    <% @employees.each do |l| %>
+      <div class="leader-card">
+        <h3><%= link_to l.name, business_leader_path(l) %></h3>
+        <div class="title"><%= l.title %></div>
+        <div style="margin-top: 6px; display: flex; gap: 6px; font-size: 0.82rem;">
+          <%= link_to "Network →", network_business_leader_path(l) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="empty">No current employees recorded.</p>
+<% end %>
+
+<% if @board.any? %>
+  <div class="section-title">Board Members</div>
+  <div class="leader-grid">
+    <% @board.each do |l| %>
+      <div class="leader-card" style="border-left-color: #8e44ad;">
+        <h3><%= link_to l.name, business_leader_path(l) %></h3>
+        <div class="title"><%= l.title %></div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @alumni.any? %>
+  <div class="section-title">Alumni</div>
+  <div class="card">
+    <table>
+      <thead><tr><th>Name</th><th>Title</th><th>Period</th></tr></thead>
+      <tbody>
+        <% @alumni.each do |l| %>
+          <tr>
+            <td><%= link_to l.name, business_leader_path(l) %></td>
+            <td><%= l.respond_to?(:role_title) ? l.role_title : '' %></td>
+            <td style="font-size:0.82rem; color:#7f8c8d;"></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,64 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>FirstApp</title>
+  <title>Business Leader Network</title>
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
   <%= csrf_meta_tags %>
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 0; background: #f5f7fa; color: #2c3e50; }
+    .navbar { background: #1a2a4a; color: white; padding: 14px 24px; display: flex; align-items: center; gap: 32px; }
+    .navbar .brand { font-size: 1.2rem; font-weight: 700; color: #5dade2; text-decoration: none; letter-spacing: 0.5px; }
+    .navbar a { color: #cdd8e8; text-decoration: none; font-size: 0.9rem; }
+    .navbar a:hover { color: white; }
+    .container { max-width: 1100px; margin: 32px auto; padding: 0 20px; }
+    .card { background: white; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.07); padding: 24px; margin-bottom: 20px; }
+    .card h2 { margin: 0 0 16px; font-size: 1.1rem; color: #1a2a4a; }
+    h1 { font-size: 1.6rem; color: #1a2a4a; margin: 0 0 24px; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; }
+    .badge-industry { background: #e8f4fd; color: #1a6fa0; }
+    .badge-degree { background: #e8fdf4; color: #1a6f4a; }
+    .leader-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
+    .leader-card { background: white; border-radius: 8px; box-shadow: 0 1px 6px rgba(0,0,0,0.08); padding: 18px; border-left: 4px solid #5dade2; }
+    .leader-card h3 { margin: 0 0 4px; font-size: 1rem; }
+    .leader-card .title { font-size: 0.85rem; color: #7f8c8d; margin-bottom: 6px; }
+    .leader-card .company { font-size: 0.85rem; color: #1a6fa0; font-weight: 500; }
+    .stat-row { display: flex; gap: 20px; flex-wrap: wrap; }
+    .stat-box { background: white; border-radius: 8px; padding: 20px 28px; text-align: center; box-shadow: 0 1px 6px rgba(0,0,0,0.07); flex: 1; min-width: 120px; }
+    .stat-box .number { font-size: 2rem; font-weight: 700; color: #5dade2; }
+    .stat-box .label  { font-size: 0.8rem; color: #7f8c8d; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+    th { text-align: left; border-bottom: 2px solid #edf2f7; padding: 8px 12px; color: #7f8c8d; font-weight: 600; font-size: 0.8rem; text-transform: uppercase; }
+    td { padding: 10px 12px; border-bottom: 1px solid #f0f4f8; }
+    tr:last-child td { border-bottom: none; }
+    a { color: #1a6fa0; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .path-chain { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: 16px 0; }
+    .path-node { background: #e8f4fd; border-radius: 6px; padding: 8px 14px; font-size: 0.88rem; border: 1px solid #b3d7f0; }
+    .path-arrow { color: #5dade2; font-weight: bold; font-size: 1.2rem; }
+    .search-bar { display: flex; gap: 10px; margin-bottom: 24px; }
+    .search-bar input { flex: 1; padding: 10px 14px; border: 1px solid #d5dce6; border-radius: 6px; font-size: 0.95rem; }
+    .search-bar button { padding: 10px 20px; background: #5dade2; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 0.95rem; }
+    .search-bar button:hover { background: #3498db; }
+    .influence-bar { display: inline-block; height: 6px; background: #5dade2; border-radius: 3px; vertical-align: middle; margin-right: 8px; }
+    .section-title { font-size: 0.95rem; font-weight: 700; color: #4a5568; text-transform: uppercase; letter-spacing: 0.5px; margin: 24px 0 12px; border-bottom: 1px solid #e2e8f0; padding-bottom: 6px; }
+    .empty { color: #aab; font-style: italic; font-size: 0.9rem; padding: 16px 0; }
+  </style>
 </head>
 <body>
 
-<%= yield %>
+<nav class="navbar">
+  <%= link_to "Business Leader Network", network_path, class: "brand" %>
+  <%= link_to "Leaders",      business_leaders_path %>
+  <%= link_to "Companies",    companies_path %>
+  <%= link_to "Top Connectors", top_connectors_network_path %>
+  <%= link_to "By Industry",  by_industry_network_path %>
+</nav>
+
+<div class="container">
+  <%= yield %>
+</div>
 
 </body>
 </html>

--- a/app/views/network/by_industry.html.erb
+++ b/app/views/network/by_industry.html.erb
@@ -1,0 +1,45 @@
+<h1>Leaders by Industry</h1>
+
+<div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap;">
+  <% (@industries || []).each do |row| %>
+    <%= link_to row['industry'], by_industry_network_path(industry: row['industry']),
+        class: "badge badge-industry",
+        style: row['industry'] == @industry ? "background:#1a6fa0;color:white;" : "" %>
+  <% end %>
+</div>
+
+<% if @industry.present? %>
+  <div class="card">
+    <h2><%= @industry %></h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Title</th>
+          <th>Company</th>
+          <th>Connections</th>
+          <th>Influence</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @leaders.each do |l| %>
+          <tr>
+            <td><%= link_to l['name'], business_leader_path(l['id']) %></td>
+            <td><%= l['title'] %></td>
+            <td><%= l['company_name'] %></td>
+            <td><%= l['connections'] %></td>
+            <td>
+              <span class="influence-bar" style="width: <%= [l['influence_score'].to_i, 100].min %>px;"></span>
+              <%= l['influence_score'] %>
+            </td>
+            <td><%= link_to "Network →", network_business_leader_path(l['id']) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <% if @leaders.empty? %>
+      <p class="empty">No leaders found in this industry.</p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -1,0 +1,65 @@
+<h1>Network Dashboard</h1>
+
+<div class="stat-row">
+  <div class="stat-box">
+    <div class="number"><%= @stats[:leaders] %></div>
+    <div class="label">Business Leaders</div>
+  </div>
+  <div class="stat-box">
+    <div class="number"><%= @stats[:companies] %></div>
+    <div class="label">Companies</div>
+  </div>
+  <div class="stat-box">
+    <div class="number"><%= @stats[:connections] %></div>
+    <div class="label">Connections</div>
+  </div>
+  <div class="stat-box">
+    <div class="number"><%= @stats[:board_seats] %></div>
+    <div class="label">Board Seats</div>
+  </div>
+</div>
+
+<div class="card" style="margin-top: 28px;">
+  <h2>Top Influencers</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Title</th>
+        <th>Company</th>
+        <th>Influence</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @top_leaders.each do |l| %>
+        <tr>
+          <td><%= link_to l['name'], business_leader_path(l['id']) %></td>
+          <td><%= l['title'] %></td>
+          <td><%= l['company_name'] %></td>
+          <td>
+            <span class="influence-bar" style="width: <%= [l['influence_score'].to_i, 100].min %>px;"></span>
+            <%= l['influence_score'] %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<div class="card">
+  <h2>Leaders by Industry</h2>
+  <table>
+    <thead>
+      <tr><th>Industry</th><th>Leaders</th><th></th></tr>
+    </thead>
+    <tbody>
+      <% @industries.each do |row| %>
+        <tr>
+          <td><span class="badge badge-industry"><%= row['industry'] %></span></td>
+          <td><%= row['leader_count'] %></td>
+          <td><%= link_to "Browse →", by_industry_network_path(industry: row['industry']) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/network/top_connectors.html.erb
+++ b/app/views/network/top_connectors.html.erb
@@ -1,0 +1,35 @@
+<h1>Top Connectors</h1>
+<p style="color:#7f8c8d; margin-bottom:24px;">
+  These leaders have the highest number of direct connections — the ideal warm-introduction
+  brokers for reaching new B2B prospects across the network.
+</p>
+
+<div class="card">
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>Title</th>
+        <th>Company</th>
+        <th>Connections</th>
+        <th>Influence</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @connectors.each_with_index do |l, i| %>
+        <tr>
+          <td style="color:#aaa;"><%= i + 1 %></td>
+          <td><%= link_to l['name'], business_leader_path(l['id']) %></td>
+          <td><%= l['title'] %></td>
+          <td><%= l['company_name'] %></td>
+          <td><strong><%= l['degree'] %></strong></td>
+          <td>
+            <span class="influence-bar" style="width: <%= [l['influence_score'].to_i, 100].min %>px;"></span>
+            <%= l['influence_score'] %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/initializers/neo4j.rb
+++ b/config/initializers/neo4j.rb
@@ -1,0 +1,34 @@
+require_relative '../../lib/neo4j/client'
+
+# Shared Neo4j client instance — configure via environment variables:
+#   NEO4J_URL       (default: http://localhost:7474)
+#   NEO4J_USERNAME  (default: neo4j)
+#   NEO4J_PASSWORD  (default: password)
+NEO4J = Neo4j::Client.new
+
+# Schema / index creation runs once at boot.
+# Using Neo4j 2.x+ constraint + index syntax.
+SCHEMA_STATEMENTS = [
+  # Uniqueness constraints implicitly create an index
+  'CREATE CONSTRAINT ON (l:BusinessLeader) ASSERT l.id IS UNIQUE',
+  'CREATE CONSTRAINT ON (c:Company)        ASSERT c.id IS UNIQUE',
+  'CREATE CONSTRAINT ON (i:Industry)       ASSERT i.name IS UNIQUE',
+
+  # Extra index for fast full-text-style searches
+  'CREATE INDEX ON :BusinessLeader(name)',
+  'CREATE INDEX ON :BusinessLeader(email)',
+  'CREATE INDEX ON :Company(name)',
+].freeze
+
+begin
+  SCHEMA_STATEMENTS.each do |stmt|
+    begin
+      NEO4J.query(stmt)
+    rescue Neo4j::Client::QueryError => e
+      # Ignore "already exists" errors on repeated boots
+      raise unless e.message.include?('already exists') || e.message.include?('Equivalent index')
+    end
+  end
+rescue => e
+  Rails.logger.warn "[Neo4j] Schema setup skipped: #{e.message}"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,49 +1,23 @@
 FirstApp::Application.routes.draw do
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
+  # Network dashboard — root of the application
+  root to: 'network#index'
 
-  # You can have the root of your site routed with "root"
-  # root to: 'welcome#index'
+  # Network-level intelligence views
+  scope :network, as: :network do
+    get '/',            to: 'network#index',        as: ''
+    get 'top_connectors', to: 'network#top_connectors', as: 'top_connectors'
+    get 'by_industry',    to: 'network#by_industry',    as: 'by_industry'
+  end
 
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
+  # Business leaders with nested graph-query actions
+  resources :business_leaders, only: [:index, :show] do
+    member do
+      get :network   # extended N-hop reachability
+      get :path      # introduction path to a target leader
+      get :mutual    # mutual connections with another leader
+    end
+  end
 
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  # Companies
+  resources :companies, only: [:index, :show]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,198 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+# Business Leader Network — seed data
 #
-# Examples:
+# Mirrors the Kantwert / Neo4j use case:
+#   - B2B sales and marketing network of senior business leaders
+#   - Graph captures professional connections, company affiliations,
+#     board memberships, and career history
+#   - Run:  rake db:seed
 #
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+require_relative '../lib/neo4j/client'
+require_relative '../config/initializers/neo4j'
+
+# ── Wipe existing data ────────────────────────────────────────────────────────
+puts "Clearing existing graph data…"
+NEO4J.query("MATCH (n) DETACH DELETE n")
+
+# ── Companies ─────────────────────────────────────────────────────────────────
+puts "Creating companies…"
+
+companies = {}
+[
+  { id: "c-finvest",   name: "FinVest Capital",      industry: "FinTech",        size: "200-500",   hq_city: "Frankfurt",  website: "https://finvest.example.com",   description: "Digital investment platform for institutional clients." },
+  { id: "c-bluerock",  name: "BlueRock Analytics",   industry: "Data & AI",      size: "500-1000",  hq_city: "Berlin",     website: "https://bluerock.example.com",  description: "Enterprise AI and predictive analytics." },
+  { id: "c-nordsec",   name: "NordSec GmbH",         industry: "Cybersecurity",  size: "100-200",   hq_city: "Hamburg",    website: "https://nordsec.example.com",   description: "B2B cybersecurity solutions for finance and healthcare." },
+  { id: "c-terrahealth",name:"TerraHealth AG",        industry: "HealthTech",     size: "1000-5000", hq_city: "Munich",     website: "https://terrahealth.example.com",description: "Digital health records and telemedicine infrastructure." },
+  { id: "c-urbanprop", name: "UrbanProp Group",       industry: "Real Estate",    size: "50-100",    hq_city: "Cologne",    website: "https://urbanprop.example.com",  description: "Commercial real-estate investment and development." },
+  { id: "c-logiq",     name: "LogiQ Systems",         industry: "SaaS / ERP",     size: "200-500",   hq_city: "Stuttgart",  website: "https://logiq.example.com",     description: "Supply chain and ERP software for mid-market manufacturers." },
+  { id: "c-greenshift", name: "GreenShift Ventures", industry: "CleanTech",      size: "50-100",    hq_city: "Leipzig",    website: "https://greenshift.example.com", description: "VC and advisory for renewable-energy start-ups." },
+  { id: "c-alphamedia", name: "AlphaMedia Group",     industry: "Media & Comms",  size: "500-1000",  hq_city: "Munich",     website: "https://alphamedia.example.com", description: "B2B content, events, and marketing intelligence." },
+].each do |attrs|
+  NEO4J.query(<<~CYPHER, attrs.transform_keys(&:to_s))
+    MERGE (c:Company {id: $id})
+    SET c.name        = $name,
+        c.industry    = $industry,
+        c.size        = $size,
+        c.hq_city     = $hq_city,
+        c.website     = $website,
+        c.description = $description
+  CYPHER
+  companies[attrs[:id]] = attrs
+end
+
+# ── Business Leaders ──────────────────────────────────────────────────────────
+puts "Creating business leaders…"
+
+leaders = {}
+[
+  { id: "l-001", name: "Sophie Reinhardt",  title: "CEO",              email: "s.reinhardt@finvest.example.com",   linkedin_url: "https://linkedin.com/in/sophiereinhardt",  bio: "20 years in investment banking; founded FinVest after leading Deutsche Bank's digital unit.", influence_score: 95, company: "c-finvest"   },
+  { id: "l-002", name: "Marcus Heller",     title: "CTO",              email: "m.heller@bluerock.example.com",     linkedin_url: "https://linkedin.com/in/marcusheller",     bio: "AI researcher turned entrepreneur; ex-SAP Labs, PhD in machine learning.",                  influence_score: 87, company: "c-bluerock"  },
+  { id: "l-003", name: "Julia Schwarz",     title: "COO",              email: "j.schwarz@nordsec.example.com",     linkedin_url: "https://linkedin.com/in/juliaschwarz",     bio: "Scaled NordSec from 10 to 180 employees; board member at two FinTech start-ups.",          influence_score: 78, company: "c-nordsec"   },
+  { id: "l-004", name: "Tobias Keller",     title: "Managing Director",email: "t.keller@terrahealth.example.com",  linkedin_url: "https://linkedin.com/in/tobiaskeller",     bio: "Healthcare IT veteran; former CMO at Siemens Healthineers.",                               influence_score: 82, company: "c-terrahealth"},
+  { id: "l-005", name: "Lena Brandt",       title: "CFO",              email: "l.brandt@urbanprop.example.com",    linkedin_url: "https://linkedin.com/in/lenabrandt",       bio: "Structured finance specialist; ex-Goldman Sachs real-estate division.",                      influence_score: 74, company: "c-urbanprop" },
+  { id: "l-006", name: "Felix Wagner",      title: "CEO",              email: "f.wagner@logiq.example.com",        linkedin_url: "https://linkedin.com/in/felixwagner",      bio: "Serial SaaS founder; previously exited two ERP ventures.",                                  influence_score: 80, company: "c-logiq"     },
+  { id: "l-007", name: "Anna Bauer",        title: "Partner",          email: "a.bauer@greenshift.example.com",    linkedin_url: "https://linkedin.com/in/annabauer",        bio: "CleanTech investor with 15 portfolio companies across wind, solar, and storage.",            influence_score: 88, company: "c-greenshift"},
+  { id: "l-008", name: "Daniel Koch",       title: "Chief Strategy Officer", email: "d.koch@alphamedia.example.com",linkedin_url: "https://linkedin.com/in/danielkoch",      bio: "Media strategist; advisory roles at three DAX-40 communications boards.",                   influence_score: 70, company: "c-alphamedia"},
+  { id: "l-009", name: "Nina Vogel",        title: "VP Sales",         email: "n.vogel@bluerock.example.com",      linkedin_url: "https://linkedin.com/in/ninavogel",        bio: "Enterprise sales leader; runs BlueRock's DACH revenue team.",                               influence_score: 62, company: "c-bluerock"  },
+  { id: "l-010", name: "Christoph Müller",  title: "Head of Products", email: "c.mueller@finvest.example.com",     linkedin_url: "https://linkedin.com/in/christophmueller",  bio: "Product-led growth specialist; ex-N26 and Wefox.",                                          influence_score: 65, company: "c-finvest"   },
+  { id: "l-011", name: "Sarah Fischer",     title: "CIO",              email: "s.fischer@terrahealth.example.com", linkedin_url: "https://linkedin.com/in/sarahfischer",     bio: "Cloud and data architecture expert; led TerraHealth's migration to Azure.",                  influence_score: 71, company: "c-terrahealth"},
+  { id: "l-012", name: "Patrick Neumann",   title: "COO",              email: "p.neumann@logiq.example.com",       linkedin_url: "https://linkedin.com/in/patrickneumann",   bio: "Operations expert; previously ran EMEA operations for Oracle.",                              influence_score: 68, company: "c-logiq"     },
+  { id: "l-013", name: "Eva Hoffmann",      title: "CEO",              email: "e.hoffmann@urbanprop.example.com",  linkedin_url: "https://linkedin.com/in/evahoffmann",      bio: "Real-estate development leader; responsible for 2B EUR in assets under management.",         influence_score: 76, company: "c-urbanprop" },
+  { id: "l-014", name: "Klaus Berger",      title: "CISO",             email: "k.berger@nordsec.example.com",      linkedin_url: "https://linkedin.com/in/klausberger",      bio: "Cybersecurity architect; 18 years protecting financial-sector infrastructure.",              influence_score: 72, company: "c-nordsec"   },
+  { id: "l-015", name: "Mia Schreiber",     title: "Head of Marketing",email: "m.schreiber@alphamedia.example.com",linkedin_url: "https://linkedin.com/in/miaschreiber",     bio: "B2B brand strategist; keynote speaker at dmexco and Marketing Week.",                       influence_score: 60, company: "c-alphamedia"},
+  { id: "l-016", name: "Oliver Ziegler",    title: "Angel Investor",   email: "o.ziegler@independent.example.com", linkedin_url: "https://linkedin.com/in/oliverziegler",    bio: "Ex-CTO turned angel; 25+ portfolio companies in SaaS and FinTech.",                         influence_score: 91, company: nil           },
+  { id: "l-017", name: "Hannah Braun",      title: "VP Engineering",   email: "h.braun@nordsec.example.com",       linkedin_url: "https://linkedin.com/in/hannahbraun",      bio: "Security engineering leader; PhD in cryptography from TU Berlin.",                          influence_score: 66, company: "c-nordsec"   },
+  { id: "l-018", name: "Lukas Hartmann",    title: "CPO",              email: "l.hartmann@bluerock.example.com",   linkedin_url: "https://linkedin.com/in/lukashartmann",    bio: "Product leader focused on ML-driven decision intelligence.",                                influence_score: 69, company: "c-bluerock"  },
+  { id: "l-019", name: "Sabine Werner",     title: "CFO",              email: "s.werner@greenshift.example.com",   linkedin_url: "https://linkedin.com/in/sabinewerner",     bio: "Green finance expert; structured the first German green bond for a start-up.",              influence_score: 73, company: "c-greenshift"},
+  { id: "l-020", name: "Thomas Schäfer",    title: "Managing Partner", email: "t.schaefer@greenshift.example.com", linkedin_url: "https://linkedin.com/in/thomasschaefer",   bio: "20-year renewable-energy investor; advisory board at IRENA.",                               influence_score: 85, company: "c-greenshift"},
+].each do |attrs|
+  company_id = attrs.delete(:company)
+  NEO4J.query(<<~CYPHER, attrs.transform_keys(&:to_s))
+    MERGE (l:BusinessLeader {id: $id})
+    SET l.name            = $name,
+        l.title           = $title,
+        l.email           = $email,
+        l.linkedin_url    = $linkedin_url,
+        l.bio             = $bio,
+        l.influence_score = toInteger($influence_score)
+  CYPHER
+
+  if company_id
+    NEO4J.query(<<~CYPHER, leader_id: attrs[:id], company_id: company_id)
+      MATCH (l:BusinessLeader {id: $leader_id}), (c:Company {id: $company_id})
+      MERGE (l)-[:WORKS_AT {current: true, since: '2019'}]->(c)
+    CYPHER
+  end
+
+  leaders[attrs[:id]] = attrs
+end
+
+# ── Professional Connections (KNOWS) ─────────────────────────────────────────
+puts "Creating connections…"
+
+connections = [
+  # Sophie (CEO FinVest) is a central hub
+  ["l-001", "l-002", "2018", "conference",    9],
+  ["l-001", "l-005", "2015", "board",         8],
+  ["l-001", "l-007", "2020", "investment",    9],
+  ["l-001", "l-016", "2017", "mentorship",   10],
+  ["l-001", "l-010", "2019", "colleague",     7],
+  ["l-001", "l-008", "2021", "event",         6],
+
+  # Marcus (CTO BlueRock) tech cluster
+  ["l-002", "l-009", "2019", "colleague",     8],
+  ["l-002", "l-018", "2018", "colleague",     9],
+  ["l-002", "l-011", "2017", "conference",    7],
+  ["l-002", "l-016", "2016", "alumni",        8],
+  ["l-002", "l-006", "2020", "conference",    6],
+
+  # Julia (COO NordSec) operations cluster
+  ["l-003", "l-014", "2016", "colleague",     9],
+  ["l-003", "l-017", "2018", "colleague",     8],
+  ["l-003", "l-004", "2019", "conference",    6],
+  ["l-003", "l-012", "2020", "peer_group",    7],
+
+  # Tobias (MD TerraHealth)
+  ["l-004", "l-011", "2015", "colleague",    10],
+  ["l-004", "l-007", "2021", "investment",    7],
+  ["l-004", "l-016", "2018", "board",         8],
+
+  # Felix (CEO LogiQ)
+  ["l-006", "l-012", "2014", "colleague",     9],
+  ["l-006", "l-016", "2019", "investor",      9],
+  ["l-006", "l-008", "2021", "event",         5],
+
+  # Anna (Partner GreenShift) — key bridge to CleanTech
+  ["l-007", "l-019", "2017", "colleague",     9],
+  ["l-007", "l-020", "2015", "colleague",    10],
+  ["l-007", "l-013", "2020", "conference",    6],
+  ["l-007", "l-005", "2019", "board",         7],
+
+  # Oliver Ziegler (Angel) — super-connector
+  ["l-016", "l-013", "2016", "investment",    8],
+  ["l-016", "l-015", "2018", "advisory",      7],
+  ["l-016", "l-019", "2020", "conference",    6],
+  ["l-016", "l-020", "2017", "investment",    9],
+
+  # Daniel / Media cluster
+  ["l-008", "l-015", "2019", "colleague",     8],
+  ["l-008", "l-013", "2021", "event",         5],
+
+  # Cross-cluster bridges (important for network analysis)
+  ["l-009", "l-010", "2020", "conference",    6],
+  ["l-010", "l-018", "2021", "peer_group",    7],
+  ["l-011", "l-017", "2019", "conference",    5],
+  ["l-014", "l-016", "2017", "advisory",      7],
+  ["l-005", "l-013", "2010", "colleague",     8],
+  ["l-019", "l-020", "2013", "colleague",    10],
+  ["l-012", "l-006", "2015", "colleague",     9],
+  ["l-015", "l-009", "2022", "event",         4],
+]
+
+connections.each do |a_id, b_id, since, source, strength|
+  NEO4J.query(<<~CYPHER, a: a_id, b: b_id, since: since, source: source, strength: strength)
+    MATCH (a:BusinessLeader {id: $a}), (b:BusinessLeader {id: $b})
+    MERGE (a)-[:KNOWS {since: $since, source: $source, strength: $strength}]->(b)
+  CYPHER
+end
+
+# ── Board Memberships ─────────────────────────────────────────────────────────
+puts "Creating board memberships…"
+
+[
+  ["l-001", "c-bluerock",   "2020"],
+  ["l-007", "c-terrahealth","2019"],
+  ["l-016", "c-logiq",      "2021"],
+  ["l-016", "c-finvest",    "2018"],
+  ["l-004", "c-nordsec",    "2020"],
+  ["l-008", "c-greenshift", "2022"],
+  ["l-005", "c-urbanprop",  "2015"],
+].each do |leader_id, company_id, since|
+  NEO4J.query(<<~CYPHER, leader_id: leader_id, company_id: company_id, since: since)
+    MATCH (l:BusinessLeader {id: $leader_id}), (c:Company {id: $company_id})
+    MERGE (l)-[:BOARD_MEMBER_OF {since: $since}]->(c)
+  CYPHER
+end
+
+# ── Work History ──────────────────────────────────────────────────────────────
+puts "Creating work history…"
+
+[
+  ["l-001", "c-alphamedia", "2010", "2014", "Head of Finance"],
+  ["l-002", "c-logiq",      "2013", "2017", "Lead Engineer"],
+  ["l-005", "c-finvest",    "2012", "2016", "Senior Analyst"],
+  ["l-006", "c-bluerock",   "2011", "2014", "Co-Founder"],
+  ["l-009", "c-finvest",    "2016", "2019", "Sales Manager"],
+  ["l-010", "c-nordsec",    "2015", "2019", "Product Manager"],
+  ["l-016", "c-bluerock",   "2008", "2012", "CTO"],
+].each do |leader_id, company_id, from, to, title|
+  NEO4J.query(<<~CYPHER, l: leader_id, c: company_id, from: from, to: to, title: title)
+    MATCH (l:BusinessLeader {id: $l}), (c:Company {id: $c})
+    MERGE (l)-[:PREVIOUSLY_WORKED_AT {from: $from, to: $to, title: $title}]->(c)
+  CYPHER
+end
+
+puts "Seed complete. Graph contains:"
+puts "  Leaders:     #{NEO4J.query('MATCH (l:BusinessLeader) RETURN count(l) AS n').first['n']}"
+puts "  Companies:   #{NEO4J.query('MATCH (c:Company) RETURN count(c) AS n').first['n']}"
+puts "  Connections: #{NEO4J.query('MATCH ()-[r:KNOWS]->() RETURN count(r) AS n').first['n']}"
+puts "  Board seats: #{NEO4J.query('MATCH ()-[r:BOARD_MEMBER_OF]->() RETURN count(r) AS n').first['n']}"

--- a/lib/neo4j/client.rb
+++ b/lib/neo4j/client.rb
@@ -1,0 +1,84 @@
+require 'net/http'
+require 'json'
+require 'uri'
+
+# Neo4j HTTP API client
+# Talks to the Neo4j transactional Cypher HTTP endpoint.
+# Configure via config/initializers/neo4j.rb or environment variables.
+module Neo4j
+  class Client
+    BOLT_DEFAULT = 'http://localhost:7474'.freeze
+
+    class QueryError < StandardError
+      attr_reader :code
+      def initialize(msg, code = nil)
+        super(msg)
+        @code = code
+      end
+    end
+
+    def initialize(url: nil, username: nil, password: nil)
+      @url      = url      || ENV.fetch('NEO4J_URL',      BOLT_DEFAULT)
+      @username = username || ENV.fetch('NEO4J_USERNAME', 'neo4j')
+      @password = password || ENV.fetch('NEO4J_PASSWORD', 'password')
+    end
+
+    # Execute a single Cypher query and return array of result rows.
+    # Each row is a hash keyed by the column names.
+    def query(cypher, params = {})
+      uri = URI("#{@url}/db/data/transaction/commit")
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+      request.basic_auth(@username, @password)
+      request.body = JSON.generate(
+        statements: [{ statement: cypher, parameters: params }]
+      )
+
+      response = http.request(request)
+      parsed = JSON.parse(response.body)
+
+      errors = parsed['errors'] || []
+      raise QueryError.new(errors.first['message'], errors.first['code']) if errors.any?
+
+      results = parsed['results'].first || {}
+      columns = results['columns'] || []
+      rows    = results['data']    || []
+
+      rows.map do |row|
+        columns.zip(row['row']).to_h
+      end
+    end
+
+    # Run multiple queries in a single transaction
+    def batch(statements)
+      uri = URI("#{@url}/db/data/transaction/commit")
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+      request.basic_auth(@username, @password)
+      request.body = JSON.generate(
+        statements: statements.map { |s| { statement: s[:cypher], parameters: s[:params] || {} } }
+      )
+
+      response = http.request(request)
+      parsed = JSON.parse(response.body)
+
+      errors = parsed['errors'] || []
+      raise QueryError.new(errors.first['message'], errors.first['code']) if errors.any?
+
+      parsed['results']
+    end
+
+    def connected?
+      uri = URI("#{@url}/db/data/")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new(uri.path)
+      request.basic_auth(@username, @password)
+      response = http.request(request)
+      response.code.to_i == 200
+    rescue
+      false
+    end
+  end
+end

--- a/lib/tasks/neo4j.rake
+++ b/lib/tasks/neo4j.rake
@@ -1,0 +1,59 @@
+require_relative '../neo4j/client'
+
+namespace :neo4j do
+  desc "Verify Neo4j connection and print graph stats"
+  task :status => :environment do
+    if NEO4J.connected?
+      puts "Neo4j: connected (#{ENV.fetch('NEO4J_URL', 'http://localhost:7474')})"
+      {
+        "BusinessLeader nodes" => "MATCH (l:BusinessLeader) RETURN count(l) AS n",
+        "Company nodes"        => "MATCH (c:Company) RETURN count(c) AS n",
+        "KNOWS relationships"  => "MATCH ()-[r:KNOWS]->() RETURN count(r) AS n",
+        "WORKS_AT rels"        => "MATCH ()-[r:WORKS_AT]->() RETURN count(r) AS n",
+        "BOARD_MEMBER_OF rels" => "MATCH ()-[r:BOARD_MEMBER_OF]->() RETURN count(r) AS n",
+      }.each do |label, cypher|
+        count = NEO4J.query(cypher).first&.fetch('n', 0)
+        printf "  %-26s %d\n", label, count
+      end
+    else
+      puts "Neo4j: NOT reachable at #{ENV.fetch('NEO4J_URL', 'http://localhost:7474')}"
+      puts "  Start Neo4j and set NEO4J_URL, NEO4J_USERNAME, NEO4J_PASSWORD env vars."
+      exit 1
+    end
+  end
+
+  desc "Drop all nodes and relationships from the graph"
+  task :reset => :environment do
+    print "This will delete ALL graph data. Type 'yes' to confirm: "
+    input = $stdin.gets.chomp
+    if input == 'yes'
+      NEO4J.query("MATCH (n) DETACH DELETE n")
+      puts "Graph cleared."
+    else
+      puts "Aborted."
+    end
+  end
+
+  desc "Run an arbitrary Cypher query (CYPHER=... rake neo4j:query)"
+  task :query => :environment do
+    cypher = ENV['CYPHER']
+    abort "Usage: CYPHER='MATCH ...' rake neo4j:query" unless cypher.present?
+    results = NEO4J.query(cypher)
+    if results.empty?
+      puts "(no results)"
+    else
+      puts results.map(&:inspect).join("\n")
+    end
+  end
+
+  desc "Show all top connectors (most connections)"
+  task :top_connectors => :environment do
+    rows = NEO4J.query(<<~CYPHER)
+      MATCH (l:BusinessLeader)-[:KNOWS]-(other)
+      WITH l, count(DISTINCT other) AS degree
+      RETURN l.name AS name, l.title AS title, degree
+      ORDER BY degree DESC LIMIT 10
+    CYPHER
+    rows.each { |r| printf "  %-25s %-30s %d connections\n", r['name'], r['title'], r['degree'] }
+  end
+end


### PR DESCRIPTION
Implements the graph-based B2B sales and marketing network described in the Kantwert / Neo4j article (https://neo4j.com/blog/cypher-and-gql/the-power-of-business-leader-networks/).

Graph schema
  (:BusinessLeader)-[:KNOWS]->(:BusinessLeader)
  (:BusinessLeader)-[:WORKS_AT]->(:Company)
  (:BusinessLeader)-[:BOARD_MEMBER_OF]->(:Company)
  (:BusinessLeader)-[:PREVIOUSLY_WORKED_AT]->(:Company)

Key capabilities
- Introduction path finder: shortestPath Cypher query up to 6 hops
- Top connectors view: bridge nodes ranked by degree centrality
- B2B industry targeting: all leaders + connection counts per sector
- Extended network: reachable leaders within 1–3 degrees
- Mutual connections: shared contacts between any two leaders

Files added
- lib/neo4j/client.rb            Raw HTTP client for Neo4j transactional API
- config/initializers/neo4j.rb   Connection + index/constraint setup at boot
- app/models/business_leader.rb  Graph ORM with path and network queries
- app/models/company.rb          Graph ORM for company nodes
- app/controllers/*              Three controllers (leaders, companies, network)
- app/views/**                   Full UI across 9 view templates
- db/seeds.rb                    20 leaders, 8 companies, 38 connections
- lib/tasks/neo4j.rake           Operational rake tasks

https://claude.ai/code/session_011KFG93TXcjZMhSgM6iFJ5T